### PR TITLE
Fixed decimal regex

### DIFF
--- a/utils/game/quiz/questionGeneration/questionFormats.js
+++ b/utils/game/quiz/questionGeneration/questionFormats.js
@@ -65,7 +65,7 @@ const QuestionFormats = {
         answerBoxMessage: 'time_only',
     },
     'decimal': {
-        validationRegex : /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/,
+        validationRegex : /^[+-]?(\d*\.)?\d+$/,
         validationFailMessage: 'invalid_decimal',
         answerBoxType: 'textInput',
         answerBoxMessage: 'decimals_only',

--- a/utils/game/restaurant/restaurantQuestionGenerators/generateSingleMultiplyDishQuestions.js
+++ b/utils/game/restaurant/restaurantQuestionGenerators/generateSingleMultiplyDishQuestions.js
@@ -495,8 +495,8 @@ function generateLevel3BQuestions(dishes,order,randomInt) {
     // create question
     generatedQuestions.push(createGameQuestion(
         {
-            en:`If 20/100 is the amount you pay and is represented as .20 in decimals, how would you represent ${x}/100 of your bill as a decimal?`,
-            es:`Si 20/100 es la cantidad que paga y se representa como .20 en decimales, ¿cómo representaría ${x}/100 de su factura como un decimal?`,
+            en:`If 20/100 is the amount you pay and is represented as .20 in decimals, how would you represent ${x}/100 as a decimal?`,
+            es:`Si 20/100 es la cantidad que paga y se representa como .20 en decimales, ¿cómo representaría ${x}/100 como un decimal?`,
         },
         answer,
         [{


### PR DESCRIPTION
### Solving issue #200 where it didn't accept .1 as answer.
This was because of the regex expression for the decimal answers.

Has been fixed and now accepts decimal numbers without the 0 before the dot.
![image](https://github.com/luzeli29/iapplymath/assets/77400177/cd7dcf39-0172-48e7-9632-67b53f7c047b)
![image](https://github.com/luzeli29/iapplymath/assets/77400177/1d5d3424-6b3b-41df-9767-56e57613e136)
![image](https://github.com/luzeli29/iapplymath/assets/77400177/2599fa10-6cdd-401c-b29b-414fbdd7ac26)
![image](https://github.com/luzeli29/iapplymath/assets/77400177/ed2b17bf-2c33-48f6-8fa6-d2fed1082a63)
